### PR TITLE
New setting: draw-bold-text-with-bright-colors

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -605,6 +605,10 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
             return null;
         }
 
+        newTermuxSession.getTerminalSession().setBoldWithBright(
+            mProperties.shouldDrawBoldTextWithBrightColors()
+        );
+
         mShellManager.mTermuxSessions.add(newTermuxSession);
 
         // Remove the execution command from the pending plugin execution commands list since it has

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
@@ -255,6 +255,8 @@ public final class TerminalEmulator {
     /** If automatic scrolling of terminal is disabled */
     private boolean mAutoScrollDisabled;
 
+    private final boolean mBoldWithBright;
+
     private byte mUtf8ToFollow, mUtf8Index;
     private final byte[] mUtf8InputBuffer = new byte[4];
     private int mLastEmittedCodePoint = -1;
@@ -315,11 +317,12 @@ public final class TerminalEmulator {
         }
     }
 
-    public TerminalEmulator(TerminalOutput session, int columns, int rows, Integer transcriptRows, TerminalSessionClient client) {
+    public TerminalEmulator(TerminalOutput session, boolean boldWithBright, int columns, int rows, Integer transcriptRows, TerminalSessionClient client) {
         mSession = session;
         mScreen = mMainBuffer = new TerminalBuffer(columns, getTerminalTranscriptRows(transcriptRows), rows);
         mAltBuffer = new TerminalBuffer(columns, rows, rows);
         mClient = client;
+        mBoldWithBright = boldWithBright;
         mRows = rows;
         mColumns = columns;
         mTabStop = new boolean[mColumns];
@@ -436,8 +439,6 @@ public final class TerminalEmulator {
         return isDecsetInternalBitSet(DECSET_BIT_REVERSE_VIDEO);
     }
 
-
-
     public boolean isCursorEnabled() {
         return isDecsetInternalBitSet(DECSET_BIT_CURSOR_ENABLED);
     }
@@ -469,6 +470,11 @@ public final class TerminalEmulator {
     /** If mouse events are being sent as escape codes to the terminal. */
     public boolean isMouseTrackingActive() {
         return isDecsetInternalBitSet(DECSET_BIT_MOUSE_TRACKING_PRESS_RELEASE) || isDecsetInternalBitSet(DECSET_BIT_MOUSE_TRACKING_BUTTON_EVENT);
+    }
+
+    /** Indicates if bold should be shown with bright colors. */
+    public boolean isBoldWithBright() {
+        return mBoldWithBright;
     }
 
     private void setDefaultTabStops() {

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
@@ -59,6 +59,9 @@ public final class TerminalSession extends TerminalOutput {
     /** The exit status of the shell process. Only valid if ${@link #mShellPid} is -1. */
     int mShellExitStatus;
 
+    /** Whether to show bold text with bright colors. */
+    private boolean mBoldWithBright;
+
     /**
      * The file descriptor referencing the master half of a pseudo-terminal pair, resulting from calling
      * {@link JNI#createSubprocess(String, String, String[], String[], int[], int, int)}.
@@ -75,7 +78,6 @@ public final class TerminalSession extends TerminalOutput {
     private final String[] mArgs;
     private final String[] mEnv;
     private final Integer mTranscriptRows;
-
 
     private static final String LOG_TAG = "TerminalSession";
 
@@ -99,6 +101,12 @@ public final class TerminalSession extends TerminalOutput {
             mEmulator.updateTerminalSessionClient(client);
     }
 
+    /** Update the setting to render bold text with bright colors. This takes effect on
+     * the next call to updateSize(). */
+    public void setBoldWithBright(boolean boldWithBright) {
+        this.mBoldWithBright = boldWithBright;
+    }
+
     /** Inform the attached pty of the new size and reflow or initialize the emulator. */
     public void updateSize(int columns, int rows) {
         if (mEmulator == null) {
@@ -120,8 +128,8 @@ public final class TerminalSession extends TerminalOutput {
      * @param columns The number of columns in the terminal window.
      * @param rows    The number of rows in the terminal window.
      */
-    public void initializeEmulator(int columns, int rows) {
-        mEmulator = new TerminalEmulator(this, columns, rows, mTranscriptRows, mClient);
+    private void initializeEmulator(int columns, int rows) {
+        mEmulator = new TerminalEmulator(this, mBoldWithBright, columns, rows, mTranscriptRows, mClient);
 
         int[] processId = new int[1];
         mTerminalFileDescriptor = JNI.createSubprocess(mShellPath, mCwd, mArgs, mEnv, processId, rows, columns);

--- a/terminal-emulator/src/test/java/com/termux/terminal/TerminalTestCase.java
+++ b/terminal-emulator/src/test/java/com/termux/terminal/TerminalTestCase.java
@@ -108,7 +108,7 @@ public abstract class TerminalTestCase extends TestCase {
 
 	protected TerminalTestCase withTerminalSized(int columns, int rows) {
 	    // The tests aren't currently using the client, so a null client will suffice, a dummy client should be implemented if needed
-		mTerminal = new TerminalEmulator(mOutput, columns, rows, rows * 2, null);
+		mTerminal = new TerminalEmulator(mOutput, false, columns, rows, rows * 2, null);
 		return this;
 	}
 

--- a/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
@@ -56,6 +56,7 @@ public final class TerminalRenderer {
     /** Render the terminal to a canvas with at a specified row scroll, and an optional rectangular selection. */
     public final void render(TerminalEmulator mEmulator, Canvas canvas, int topRow,
                              int selectionY1, int selectionY2, int selectionX1, int selectionX2) {
+        final boolean boldWithBright = mEmulator.isBoldWithBright();
         final boolean reverseVideo = mEmulator.isReverseVideo();
         final int endRow = topRow + mEmulator.mRows;
         final int columns = mEmulator.mColumns;
@@ -124,7 +125,8 @@ public final class TerminalRenderer {
                         }
                         drawTextRun(canvas, line, palette, heightOffset, lastRunStartColumn, columnWidthSinceLastRun,
                             lastRunStartIndex, charsSinceLastRun, measuredWidthForRun,
-                            cursorColor, cursorShape, lastRunStyle, reverseVideo || invertCursorTextColor || lastRunInsideSelection);
+                            cursorColor, cursorShape, lastRunStyle, boldWithBright,
+                            reverseVideo || invertCursorTextColor || lastRunInsideSelection);
                     }
                     measuredWidthForRun = 0.f;
                     lastRunStyle = style;
@@ -152,13 +154,14 @@ public final class TerminalRenderer {
                 invertCursorTextColor = true;
             }
             drawTextRun(canvas, line, palette, heightOffset, lastRunStartColumn, columnWidthSinceLastRun, lastRunStartIndex, charsSinceLastRun,
-                measuredWidthForRun, cursorColor, cursorShape, lastRunStyle, reverseVideo || invertCursorTextColor || lastRunInsideSelection);
+                measuredWidthForRun, cursorColor, cursorShape, lastRunStyle, boldWithBright,
+                reverseVideo || invertCursorTextColor || lastRunInsideSelection);
         }
     }
 
     private void drawTextRun(Canvas canvas, char[] text, int[] palette, float y, int startColumn, int runWidthColumns,
                              int startCharIndex, int runWidthChars, float mes, int cursor, int cursorStyle,
-                             long textStyle, boolean reverseVideo) {
+                             long textStyle, boolean boldWithBright, boolean reverseVideo) {
         int foreColor = TextStyle.decodeForeColor(textStyle);
         final int effect = TextStyle.decodeEffect(textStyle);
         int backColor = TextStyle.decodeBackColor(textStyle);
@@ -169,8 +172,8 @@ public final class TerminalRenderer {
         final boolean dim = (effect & TextStyle.CHARACTER_ATTRIBUTE_DIM) != 0;
 
         if ((foreColor & 0xff000000) != 0xff000000) {
-            // Let bold have bright colors if applicable (one of the first 8):
-            if (bold && foreColor >= 0 && foreColor < 8) foreColor += 8;
+            // If enabled, let bold have bright colors if applicable (one of the first 8):
+            if (boldWithBright && bold && foreColor >= 0 && foreColor < 8) foreColor += 8;
             foreColor = palette[foreColor];
         }
 

--- a/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxPropertyConstants.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxPropertyConstants.java
@@ -148,6 +148,11 @@ public final class TermuxPropertyConstants {
 
 
 
+    /** Defines the key for whether to use bright colors for bold text */
+    public static final String KEY_DRAW_BOLD_TEXT_WITH_BRIGHT_COLORS =  "draw-bold-text-with-bright-colors"; // Default: "draw-bold-text-with-bright-colors"
+
+
+
     /** Defines the key for whether to use ctrl space workaround to fix the issue where ctrl+space does not work on some ROMs */
     public static final String KEY_USE_CTRL_SPACE_WORKAROUND =  "ctrl-space-workaround"; // Default: "ctrl-space-workaround"
 
@@ -400,6 +405,7 @@ public final class TermuxPropertyConstants {
         KEY_HIDE_SOFT_KEYBOARD_ON_STARTUP,
         KEY_RUN_TERMUX_AM_SOCKET_SERVER,
         KEY_TERMINAL_ONCLICK_URL_OPEN,
+        KEY_DRAW_BOLD_TEXT_WITH_BRIGHT_COLORS,
         KEY_USE_CTRL_SPACE_WORKAROUND,
         KEY_USE_FULLSCREEN,
         KEY_USE_FULLSCREEN_WORKAROUND,
@@ -449,6 +455,7 @@ public final class TermuxPropertyConstants {
         KEY_USE_CTRL_SPACE_WORKAROUND,
         KEY_USE_FULLSCREEN,
         KEY_USE_FULLSCREEN_WORKAROUND,
+        KEY_DRAW_BOLD_TEXT_WITH_BRIGHT_COLORS,
         TermuxConstants.PROP_ALLOW_EXTERNAL_APPS
     ));
 

--- a/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxSharedProperties.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxSharedProperties.java
@@ -598,6 +598,16 @@ public abstract class TermuxSharedProperties {
         return (boolean) getInternalPropertyValue(TermuxPropertyConstants.KEY_ENFORCE_CHAR_BASED_INPUT, true);
     }
 
+    public boolean shouldDrawBoldTextWithBrightColors() {
+        return (boolean) getInternalPropertyValue(TermuxPropertyConstants.KEY_DRAW_BOLD_TEXT_WITH_BRIGHT_COLORS, true);
+    }
+
+    /** Get the {@link TermuxPropertyConstants#KEY_DRAW_BOLD_TEXT_WITH_BRIGHT_COLORS} value from the properties file on disk. */
+    public static boolean shouldDrawBoldTextWithBrightColors(Context context) {
+        return (Boolean) TermuxSharedProperties.getTermuxInternalPropertyValue(context,
+            TermuxPropertyConstants.KEY_DRAW_BOLD_TEXT_WITH_BRIGHT_COLORS);
+    }
+
     public boolean shouldExtraKeysTextBeAllCaps() {
         return (boolean) getInternalPropertyValue(TermuxPropertyConstants.KEY_EXTRA_KEYS_TEXT_ALL_CAPS, true);
     }


### PR DESCRIPTION
The new setting is draw-bold-text-with-bright-colors, and it is disabled by default, as it always should have been. This is also the name Alacritty uses. Similarly, it is disabled by default.